### PR TITLE
Move compute mirror logic into async.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   ],
   "ignore": [
     "cli",
+    "demo",
     ".csslintrc",
     ".editorconfig",
     ".gitattributes",
@@ -26,10 +27,13 @@
     "package.json"
   ],
   "dependencies": {
-    "polymer": "^1.5.0",
-    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
-    "iron-icon": "^1.0.10",
     "d2l-colors": "^2.1.0",
-    "d2l-polymer-behaviors": "^0.0.3"
+    "d2l-polymer-behaviors": "^0.0.3",
+    "iron-icon": "^1.0.10",
+    "iron-iconset-svg": "polymerelements/iron-iconset-svg#^1.0.0",
+    "polymer": "^1.5.0"
+  },
+  "devDependencies": {
+    "d2l-demo-template": "~0.0.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,8 @@
     "polymer": "^1.5.0"
   },
   "devDependencies": {
-    "d2l-demo-template": "~0.0.2"
+    "d2l-demo-template": "~0.0.2",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.1.5",
+    "web-component-tester": "^4.2.2"
   }
 }

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -29,17 +29,14 @@
 	<script>
 		Polymer({
 			is: 'd2l-icon',
+
 			properties: {
-				icon: String
+				icon: {
+					type: String,
+					observer: '__onChange'
+				}
 			},
-			ready: function() {
-				this.async(function() {
-					var mirrorRtl = this.__computeMirrorRtl();
-					if (mirrorRtl) {
-						this.$$('iron-icon').setAttribute('data-mirror-rtl', '');
-					}
-				});
-			},
+
 			__findSvg: function(node) {
 				var composedChildren = D2L.Dom.getComposedChildren(node);
 				for (var i = 0; i < composedChildren.length; i++) {
@@ -54,9 +51,9 @@
 				}
 				return null;
 			},
-			__computeMirrorRtl: function() {
-				var svg = this.__findSvg(this);
-				if (svg === null) {
+
+			__computeMirrorRtl: function(svg) {
+				if (!svg) {
 					return false;
 				}
 				var gs = svg.getElementsByTagName('g');
@@ -66,7 +63,26 @@
 					}
 				}
 				return false;
+			},
+
+			__initialize: function() {
+				var svg = this.__findSvg(this);
+				if (!svg) {
+					return false;
+				}
+				/* IE prevent svg from being focusable */
+				svg.setAttribute('focusable', 'false');
+				var mirrorRtl = this.__computeMirrorRtl(svg);
+				if (mirrorRtl) {
+					this.$$('iron-icon').setAttribute('data-mirror-rtl', '');
+				}
+
+			},
+
+			__onChange: function() {
+				this.__initialize();
 			}
+
 		});
 	</script>
 </dom-module>

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -75,6 +75,8 @@
 				var mirrorRtl = this.__computeMirrorRtl(svg);
 				if (mirrorRtl) {
 					this.$$('iron-icon').setAttribute('data-mirror-rtl', '');
+				} else {
+					this.$$('iron-icon').removeAttribute('data-mirror-rtl');
 				}
 
 			},

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -33,10 +33,12 @@
 				icon: String
 			},
 			ready: function() {
-				var mirrorRtl = this.__computeMirrorRtl();
-				if (mirrorRtl) {
-					this.$$('iron-icon').setAttribute('data-mirror-rtl', '');
-				}
+				this.async(function() {
+					var mirrorRtl = this.__computeMirrorRtl();
+					if (mirrorRtl) {
+						this.$$('iron-icon').setAttribute('data-mirror-rtl', '');
+					}
+				});
 			},
 			__findSvg: function(node) {
 				var composedChildren = D2L.Dom.getComposedChildren(node);

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -65,6 +65,10 @@
 				return false;
 			},
 
+			__getIronIcon: function() {
+				return this.$$('iron-icon');
+			},
+
 			__initialize: function() {
 				var svg = this.__findSvg(this);
 				if (!svg) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,11 +3,8 @@
 <head>
 	<title>d2l-icons</title>
 	<script src="https://s.brightspace.com/lib/webcomponentsjs/0.7.21/webcomponents.min.js"></script>
-	<script>
-		window.Polymer = window.Polymer || {};
-		window.Polymer.dom = 'shadow';
-	</script>
 	<link rel="import" href="../../d2l-colors/d2l-colors.html">
+	<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
 	<link rel="import" href="../d2l-icons.html">
 	<style is="custom-style" include="d2l-colors">
 		button:hover d2l-icon,
@@ -16,29 +13,28 @@
 		}
 	</style>
 </head>
-<body>
-	<h1>&lt;d2l-icon&gt; Demo</h1>
-	<p>
-		<d2l-icon icon="d2l-tier1:print"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<d2l-icon icon="d2l-tier2:print"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<d2l-icon icon="d2l-tier3:calendar"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<button><d2l-icon icon="d2l-tier1:gear"></d2l-icon>Settings</button>
-	</p>
-	<h2>LTR</h2>
-	<p>
-		<d2l-icon icon="d2l-tier1:check-circle"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<d2l-icon icon="d2l-tier1:volume"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<d2l-icon icon="d2l-tier1:move-to"></d2l-icon>&nbsp;&nbsp;&nbsp;
-		<d2l-icon icon="d2l-html-editor:bold"></d2l-icon>
-	</p>
-	<section dir="rtl">
-		<h2>RTL</h2>
-		<p>
-			<d2l-icon icon="d2l-tier1:check-circle"></d2l-icon>&nbsp;&nbsp;&nbsp;
-			<d2l-icon icon="d2l-tier1:volume"></d2l-icon>&nbsp;&nbsp;&nbsp;
-			<d2l-icon icon="d2l-tier1:move-to"></d2l-icon>&nbsp;&nbsp;&nbsp;
-			<d2l-icon icon="d2l-html-editor:bold"></d2l-icon>
-		</p>
-	</section>
+<body unresolved>
+
+	<d2l-demo-template title="d2l-icons">
+		<div class="d2l-demo-fixture">
+
+			<h2 class="d2l-heading-4">tiers (1,2,3)</h2>
+			<p>
+				<d2l-icon icon="d2l-tier1:print"></d2l-icon>&nbsp;&nbsp;&nbsp;
+				<d2l-icon icon="d2l-tier2:print"></d2l-icon>&nbsp;&nbsp;&nbsp;
+				<d2l-icon icon="d2l-tier3:calendar"></d2l-icon>&nbsp;&nbsp;&nbsp;
+			</p>
+
+			<h2 class="d2l-heading-4">directionality</h2>
+			<p>
+				<d2l-icon icon="d2l-tier1:check-circle"></d2l-icon>&nbsp;&nbsp;&nbsp;
+				<d2l-icon icon="d2l-tier1:volume"></d2l-icon>&nbsp;&nbsp;&nbsp;
+				<d2l-icon icon="d2l-tier1:move-to"></d2l-icon>&nbsp;&nbsp;&nbsp;
+				<d2l-icon icon="d2l-html-editor:bold"></d2l-icon>
+			</p>
+
+		</div>
+	</d2l-demo-template>
+
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "postinstall": "bower install",
     "test": "npm run test:lint:js && npm run test:lint:wc && npm run build",
     "test:lint:js": "eslint *.html demo/*.html cli/*.js",
-    "test:lint:wc": "polylint --input *.html"
+    "test:lint:wc": "polylint --input *.html",
+    "test:unit:local": "wct --skip-plugin sauce"
   },
   "repository": {
     "type": "git",
@@ -43,6 +44,7 @@
     "q": "^1.4.1",
     "through2": "^2.0.1",
     "vinyl-fs": "^2.3.1",
+    "web-component-tester": "^4.2.2",
     "xml2js": "^0.4.16",
     "yargs": "^4.1.0"
   },

--- a/test/icon.html
+++ b/test/icon.html
@@ -14,10 +14,7 @@
 		<test-fixture id="icon">
 			<template>
 				<div>
-					<a id="focusable_before" href="http://www.d2l.com"></a>
-										<a id="focusable_before2" href="http://www.d2l.com"></a>
 					<d2l-icon icon="d2l-tier1:print"></d2l-icon>
-					<a id="focusable_after" href="http://www.d2l.com"></a>
 				</div>
 			</template>
 		</test-fixture>
@@ -47,7 +44,6 @@
 
 				it('initializes svg as not focusable', function() {
 					expect(icon.__findSvg(icon).getAttribute('focusable')).to.equal('false');
-										//expect(icon.__getIronIcon().getAttribute('data-mirror-rtl')).to.be.null;
 				});
 
 				it('updates svg when icon attribute changes', function() {

--- a/test/icon.html
+++ b/test/icon.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<title>d2l-icon tests</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+		<link rel="import" href="../d2l-icons.html">
+	</head>
+	<body>
+
+		<test-fixture id="icon">
+			<template>
+				<div>
+					<a id="focusable_before" href="http://www.d2l.com"></a>
+										<a id="focusable_before2" href="http://www.d2l.com"></a>
+					<d2l-icon icon="d2l-tier1:print"></d2l-icon>
+					<a id="focusable_after" href="http://www.d2l.com"></a>
+				</div>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="icon_with_mirror">
+			<template>
+				<d2l-icon icon="d2l-tier1:volume"></d2l-icon>
+			</template>
+		</test-fixture>
+
+		<script>
+
+		describe('<d2l-icon>', function() {
+
+			var iconFixture, icon;
+
+			describe('standard', function() {
+
+				beforeEach(function() {
+					iconFixture = fixture('icon');
+					icon = iconFixture.querySelector('d2l-icon');
+				});
+
+				it('finds svg', function() {
+					expect(icon.__findSvg(icon)).to.not.be.null;
+				});
+
+				it('initializes svg as not focusable', function() {
+					expect(icon.__findSvg(icon).getAttribute('focusable')).to.equal('false');
+										//expect(icon.__getIronIcon().getAttribute('data-mirror-rtl')).to.be.null;
+				});
+
+				it('updates svg when icon attribute changes', function() {
+						var originalSvg = icon.__findSvg(icon);
+						originalSvg.setAttribute('original', 'true');
+
+						icon.setAttribute('icon', 'd2l-tier1:add');
+						var updatedSvg = icon.__findSvg(icon);
+
+						expect(updatedSvg).to.not.equal(originalSvg);
+						expect(updatedSvg.getAttribute('original')).to.be.null;
+				});
+
+			});
+
+			describe('mirrored', function() {
+
+				beforeEach(function() {
+					icon = fixture('icon_with_mirror');
+				});
+
+				it('initializes iron-icon with data-mirror-rtl attribute', function() {
+					expect(icon.__findSvg(icon).querySelector('[mirror-rtl="true"]')).to.not.be.null;
+					expect(icon.__getIronIcon().getAttribute('data-mirror-rtl')).to.equal('');
+				});
+
+				it('updates iron-icon data-mirror-rtl attribute when icon changes', function() {
+					icon.setAttribute('icon', 'd2l-tier1:print');
+					expect(icon.__findSvg(icon).querySelector('[mirror-rtl="true"]')).to.be.null;
+					expect(icon.__getIronIcon().getAttribute('data-mirror-rtl')).to.be.null;
+				});
+
+			});
+
+		});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="UTF-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<title>d2l-icons tests</title>
+		<script src="../../web-component-tester/browser.js"></script>
+	</head>
+	<body>
+		<script>
+		WCT.loadSuites([
+			'icon.html',
+			'icon.html?dom=shadow'
+		]);
+		</script>
+	</body>
+</html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,0 +1,51 @@
+{
+	"plugins": {
+		"local": {
+			"browsers": ["chrome"]
+		},
+		"sauce": {
+			"browsers": [
+				{
+					"browserName": "chrome",
+					"platform": "OS X 10.11",
+					"version": ""
+				},
+				{
+					"browserName": "chrome",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "firefox",
+					"platform": "OS X 10.11",
+					"version": ""
+				},
+				{
+					"browserName": "firefox",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "safari",
+					"platform": "OS X 10.11",
+					"version": "9.0"
+				},
+				{
+					"browserName": "microsoftedge",
+					"platform": "Windows 10",
+					"version": ""
+				},
+				{
+					"browserName": "internet explorer",
+					"platform": "Windows 10",
+					"version": "11"
+				},
+				{
+					"browserName": "internet explorer",
+					"platform": "Windows 8",
+					"version": "10"
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
@dlockhart : this change wraps the compute mirror logic in `this.async` which will ensure that child components (in this case `iron-icon`) are ready when this logic runs.  There is no guarantee that the order components are `ready` in a particular order.

Background: I ran into timing issue where the `svg` was not distributed yet when this logic was run.  Wrapping in this component's `async` resolves the issue.