### PR TITLE
Fix d2l-icon height on IE (sort of)

### DIFF
--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -6,6 +6,12 @@
 	<template>
 		<style include="d2l-colors">
 			:host {
+				/*
+				 * Without this, some browsers (IE) will think the minimum
+				 * height of an iron-icon is 20px instead of 18px, which
+				 * messes up centering
+				 */
+				vertical-align: top;
 				color: var(--d2l-color-tungsten);
 				--iron-icon-height: 18px;
 				--iron-icon-width: 18px;


### PR DESCRIPTION
Doesn't seem to affect the display on other browsers.

Found using Galen in https://github.com/Brightspace/d2l-table-ui/pull/45