### PR TITLE
Fix for RTL icons.

### DIFF
--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -53,6 +53,12 @@
 				}
 			},
 
+			attached: function() {
+				this.async(function() {
+					this.__initialize();
+				});
+			},
+
 			__findSvg: function(node) {
 				var composedChildren = D2L.Dom.getComposedChildren(node);
 				for (var i = 0; i < composedChildren.length; i++) {
@@ -105,7 +111,7 @@
 				this.async(function() {
 					this.__initialize();
 					this.updateStyles(); // need to re-calc iron-icon variables
-				}, 1);
+				});
 			}
 
 		});

--- a/d2l-icon.html
+++ b/d2l-icon.html
@@ -111,7 +111,7 @@
 				this.async(function() {
 					this.__initialize();
 					this.updateStyles(); // need to re-calc iron-icon variables
-				});
+				}, 1);
 			}
 
 		});


### PR DESCRIPTION
@awikkerink, @dlockhart 

This change gets RTL icons working again (check demo page).  Basically, the `svg` was not ready yet when this code was running.  Not entirely sure why test would work while the demo page was not.  Would really like perceptual diff here.  This was previously working - it's possible that a recent change to `iron-icon` caused this regression.  

This fix merely gets this component working again - I am going to pursue updating to the recent RTL support provided by `iron-icon` in a separate PR.